### PR TITLE
Feeder On/Off commands

### DIFF
--- a/src/main/java/frc/robot/commands/FeederOff.java
+++ b/src/main/java/frc/robot/commands/FeederOff.java
@@ -40,13 +40,13 @@ public class FeederOff extends CommandBase
     @Override
     public void initialize() 
     {
-        m_feeder.feederOff();
     }
 
     // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() 
     {
+        m_feeder.feederOff();
     }
 
     // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/FeederOn.java
+++ b/src/main/java/frc/robot/commands/FeederOn.java
@@ -40,13 +40,13 @@ public class FeederOn extends CommandBase
     @Override
     public void initialize() 
     {
-        m_feeder.feederOn();
     }
 
     // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() 
     {
+        m_feeder.feederOn();
     }
 
     // Called once the command ends or is interrupted.


### PR DESCRIPTION
Fixed feeder on / off methods. Originally the code was placed in the init method in each of the classes, but then they would only be called every time an object of the class is made. Now the code is placed in the exec method in each of the classes, which allows them to be called multiple times without the need to create new objects.